### PR TITLE
Ricerca anche parzialmente il nome del piatto.

### DIFF
--- a/scripts/listapranzo.js
+++ b/scripts/listapranzo.js
@@ -126,6 +126,10 @@ module.exports = function (robot) {
       else
         msg.reply('Ok, fatto!');
     } else {
+      if (robot.brain.get('menu') === null) {
+        msg.reply('nessun menu impostato!');
+        return;
+      }
 
       var dishes = dish.split('+');
       dishes = dishes.map(function (s) { return s.trim(); });

--- a/scripts/listapranzo.js
+++ b/scripts/listapranzo.js
@@ -86,14 +86,11 @@ module.exports = function (robot) {
   };
 
   var fuzzyMatch = function (dish, menuline) {
-    dish = dish.trim().toLowerCase().replace(" ", "");
-    var key = "";
-    for (var i = 0; i < dish.length; i++)
-      key = key + dish[i] + ".*"
-
+    var key = dish.trim().toLowerCase().replace(" ", ".*") + ".*";
+    
     key = new RegExp(key, "");
 
-    menuline = menuline.trim().toLowerCase().replace(" ", "");
+    menuline = menuline.trim().toLowerCase();
 
     return key.test(menuline);
   };

--- a/scripts/listapranzo.js
+++ b/scripts/listapranzo.js
@@ -98,8 +98,9 @@ module.exports = function (robot) {
   var findDishes = function (menu, dish) {
     var matches = [];
     for (var i = 0; i < menu.length; i++) {
-      if (fuzzyMatch(dish, menu[i]))
+      if (fuzzyMatch(dish, menu[i])) {
         matches.push(menu[i]);
+      }
     }
 
     return matches;
@@ -135,17 +136,16 @@ module.exports = function (robot) {
         if (newdishes.length === 0) {
           msg.reply('mi spiace, non riesco a trovare nulla che rassomigli a "' + dishes[d] +'" nel menu.');
           return;
-        }
-        else if (newdishes.length > 1) {
+        } else if (newdishes.length > 1) {
           msg.reply('ho trovato diversi piatti che rassomigliano a "' + dishes[d] + '":')
           for (var j = 0; j < newdishes.length; j++) {
             msg.reply(newdishes[j]);
           }
           msg.reply("prova a essere più specifico nella tua richiesta.");
           return;
-        }
-        else
+        } else {
           dishes[d] = newdishes[0];
+        }
       }
 
       addNewOrder(order, dishes, user);


### PR DESCRIPTION
Aggiunge la feature di poter inserire un ordine specificando anche parzialmente il nome del piatto (e.g. "per me penne", quando il piatto era "Penne al pesto").

Se c'è più di un possibile piatto candidato, tinabot non aggiunge nulla, mostra le alternative possibili e chiede di essere più specifici.