### PR TITLE
Using weeks num

### DIFF
--- a/scripts/listapranzo.js
+++ b/scripts/listapranzo.js
@@ -192,16 +192,16 @@ module.exports = function (robot) {
   };
 
   // Whether this is a develunch week
-  var isDevelunchWeek = function(mm) {
+  var isDevelunchWeek = function() {
     var dv = robot.brain.get('develunch')
-    if (mm.week() == 1 && dv[1] !== mm.year()) {
+    if (moment().week() == 1 && dv[1] !== moment().year()) {
         // If we had odd weeks, we flip the bit
         if (moment(dv[1], "YYYY").weeksInYear() % 2)
             dv[0] = dv[0] ? 0 : 1;
-        dv[1] = mm.year();
+        dv[1] = moment().year();
         robot.brain.set("develunch", dv);
     }
-    return dv[0] === mm.week() % 2;
+    return dv[0] === moment().week() % 2;
   };
   // Whether today is the develunch day
   var isDevelunchDay = function() {


### PR DESCRIPTION
Tentative patch to use a single bit in order to store when the develunch is. When a new year begins, the stored info is updated, and if needed the bit is flipped (when we had a odd number of weeks, we must do it to avoid either doubling down or skipping two weeks).

This avoids hour logic, but requires a couple of lines to handle the new year. However it becomes easier checking whether a given week has the develunch or not.