### PR TITLE
Aggiunge link 'mailto' clickabile al comando 'email'

### DIFF
--- a/scripts/listapranzo.js
+++ b/scripts/listapranzo.js
@@ -294,7 +294,8 @@ module.exports = function (robot) {
 
   robot.respond(/email/i, function (msg) {
     var order = getOrder();
-    var reply = ["Ordine Develer del giorno " + formatDate(order.timestamp)];
+    var subject = "Ordine Develer del giorno " + formatDate(order.timestamp);
+    var reply = [];
 
     for (var dish in order.dishes) {
       if (order.dishes.hasOwnProperty(dish)) {
@@ -304,7 +305,14 @@ module.exports = function (robot) {
       }
     }
 
-    msg.reply(reply.join('\n'));
+    var body = reply.join('\n');
+
+    msg.reply(subject + "\n" + body + "\n\n"
+      + "<mailto:info@tuttobene-bar.it,sara@tuttobene-bar.it"
+      + "?subject=" + encodeURIComponent(subject)
+      + "&body=" + encodeURIComponent(body)
+      + "|Link `mailto` clickabile>"
+    );
   });
 
   robot.respond(/menu([\s\S]*)?/i, function (msg) {


### PR DESCRIPTION
Risolve #10 aggiungendo un link `mailto:` clickabile in fondo al comando `email`.

*In teoria*, stando alla documentazione di Slack, dovrebbe anche farne un pretty-print grazie alla sintassi `<mailto:send@stuff.com|Pretty link>`, ma hubot non permette di testarlo in locale e tramite client desktop *non va™*, per cui sarà una sorpresa :tada: 